### PR TITLE
Update Cargo.toml

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 [dependencies]
 byteorder = "1.0"
 flate2 = { version = "0.2", features = ["zlib"], default-features = false }
-uuid = { version = "0.5", optional = true }
+uuid = { version = "0.6", optional = true }
 error-chain = "0.10"
 num-traits = "0.1"
 


### PR DESCRIPTION
Hey

Updating this crate to 0.6 since the new release is out. There are no further changes required.