### PR TITLE
Implement Parcel for std::ffi::CString

### DIFF
--- a/protocol/src/errors.rs
+++ b/protocol/src/errors.rs
@@ -55,7 +55,7 @@ error_chain! {
     foreign_links {
         Io(std::io::Error);
         FromUtf8(std::string::FromUtf8Error);
-        FromFfi(std::ffi::NulError);
+        FromNulError(std::ffi::NulError);
         TryFromIntError(TryFromIntError);
         CharTryFromError(CharTryFromError);
 

--- a/protocol/src/errors.rs
+++ b/protocol/src/errors.rs
@@ -55,6 +55,7 @@ error_chain! {
     foreign_links {
         Io(std::io::Error);
         FromUtf8(std::string::FromUtf8Error);
+        FromFfi(std::ffi::NulError);
         TryFromIntError(TryFromIntError);
         CharTryFromError(CharTryFromError);
 

--- a/protocol/src/types/cstring.rs
+++ b/protocol/src/types/cstring.rs
@@ -1,0 +1,61 @@
+use std::ffi::CString;
+use std::io::prelude::{Read, Write};
+use {hint, Error, Parcel, Settings};
+
+impl Parcel for CString {
+    const TYPE_NAME: &'static str = "CString";
+
+    fn read_field(
+        read: &mut dyn Read,
+        settings: &Settings,
+        _hints: &mut hint::Hints,
+    ) -> Result<Self, Error> {
+        let mut result = Vec::new();
+        loop {
+            let c: u8 = Parcel::read(read, settings)?;
+            if c == 0x00 {
+                break;
+            }
+            result.push(c);
+        }
+        Ok(CString::new(result)?)
+    }
+
+    fn write_field(
+        &self,
+        write: &mut dyn Write,
+        settings: &Settings,
+        _hints: &mut hint::Hints,
+    ) -> Result<(), Error> {
+        for c in self.clone().into_bytes() {
+            c.write(write, settings)?;
+            if c == 0x00 {
+                return Ok(());
+            }
+        }
+        0u8.write(write, settings)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {Parcel, Settings};
+    use std::io::Cursor;
+    use std::ffi::CString;
+
+    #[test]
+    fn can_read_cstring() {
+        let mut data = Cursor::new([0x41, 0x42, 0x43, 0]);
+        let read_back: CString = Parcel::read(&mut data, &Settings::default()).unwrap();
+        assert_eq!(read_back, CString::new("ABC").unwrap());
+    }
+
+    #[test]
+    fn can_write_cstring() {
+        let mut buffer = Cursor::new(Vec::new());
+
+        CString::new("ABC").unwrap().write(&mut buffer, &Settings::default()).unwrap();
+        assert_eq!(buffer.into_inner(), vec![0x41, 0x42, 0x43, 0]);
+    }
+}

--- a/protocol/src/types/mod.rs
+++ b/protocol/src/types/mod.rs
@@ -10,6 +10,7 @@ mod array;
 mod char;
 /// Definitions for the `std::collections` module.
 mod collections;
+mod cstring;
 mod marker;
 mod numerics;
 mod option;


### PR DESCRIPTION
This allows protocols to implement null terminated strings

Resolves #21 