### PR TITLE
Update/Fix README (two code snippet typos / updated URLs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The protocol you define can be used outside of networking too - see the `Parcel:
 
 This crate also provides:
 
-* [TCP](https://docs.rs/protocol/0.3.4/protocol/wire/stream/index.html) and [UDP](https://docs.rs/protocol/0.3.4/protocol/wire/dgram/index.html) modules for easy sending and receiving of `Parcel`s
-* A generic [middleware](https://docs.rs/protocol/0.3.4/protocol/wire/middleware/index.html) library for automatic transformation of sent/received data
-  * Middleware has already been written to support [compression](https://docs.rs/protocol/0.3.4/protocol/wire/middleware/compression/index.html)
+* [TCP](https://docs.rs/protocol/latest/protocol/wire/stream/index.html) and [UDP](https://docs.rs/protocol/latest/protocol/wire/dgram/index.html) modules for easy sending and receiving of `Parcel`s
+* A generic [middleware](https://docs.rs/protocol/latest/protocol/wire/middleware/index.html) library for automatic transformation of sent/received data
+  * Middleware has already been written to support [compression](https://docs.rs/protocol/latest/protocol/wire/middleware/compression/index.html)
   * Custom middleware can be implemented via a trait with two methods
 
 Checkout the [examples](./examples) folder for usage.
@@ -36,7 +36,7 @@ protocol-derive = "3.1"
 
 ## Under the hood
 
-The most interesting part here is the [`protocol::Parcel`](https://docs.rs/protocol/0.3.4/protocol/trait.Parcel.html) trait. Any type that implements this trait can then be serialized to and from a byte stream. All primitive types, standard collections, tuples, and arrays implement this trait.
+The most interesting part here is the [`protocol::Parcel`](https://docs.rs/protocol/latest/protocol/trait.Parcel.html) trait. Any type that implements this trait can then be serialized to and from a byte stream. All primitive types, standard collections, tuples, and arrays implement this trait.
 
 This crate becomes particularly useful when you define your own `Parcel` types. You can use `#[derive(Protocol)]` to do this. Note that in order for a type to implement `Parcel`, it must also implement `Clone`, `Debug`, and `PartialEq`.
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ The most interesting part here is the [`protocol::Parcel`](https://docs.rs/proto
 This crate becomes particularly useful when you define your own `Parcel` types. You can use `#[derive(Protocol)]` to do this. Note that in order for a type to implement `Parcel`, it must also implement `Clone`, `Debug`, and `PartialEq`.
 
 ```rust
-#[derive(Parcel, Clone, Debug, PartialEq]
+#[derive(Parcel, Clone, Debug, PartialEq)]
 pub struct Health(f32);
 
-#[derive(Parcel, Clone, Debug, PartialEq]
+#[derive(Parcel, Clone, Debug, PartialEq)]
 pub struct SetPlayerPosition {
     pub position: (f32, f32),
     pub health: Health,


### PR DESCRIPTION
First code snippet was missing the closing braces on `#[derive(Parcel, Clone, Debug, PartialEq)]`